### PR TITLE
Implement switch event notification

### DIFF
--- a/qemu_src/hw/misc/idt_ntb_ivshmem.c
+++ b/qemu_src/hw/misc/idt_ntb_ivshmem.c
@@ -201,6 +201,9 @@ enum idt_global_config_registers {
     IDT_SW_SWP0MSGCTL0     = 0x3EE00U,
 
     /* Switch event registers */
+    IDT_SW_SESTS           = 0x3EC00U,
+    IDT_SW_SELINKUPSTS     = 0x3EC0CU,
+    IDT_SW_SELINKDNSTS     = 0x3EC14U,
     IDT_SW_SEGSIGSTS       = 0x3EC30U,
     IDT_SW_SEGSIGMSK       = 0x3EC34U,
 };
@@ -425,6 +428,10 @@ static uint64_t get_gasadata(IVShmemState *s)
             ret = shm_storage->vm2.regs.ntctl;
             IVSHMEM_DPRINTF("GAS: Read switch port 2 NTCTL: 0x%lx\n", ret);
             break;
+        case IDT_SW_SESTS:
+            ret = 0ULL;
+            IVSHMEM_DPRINTF("GAS: Stub read of SESTS (not used by Linux driver)\n");
+            break;
 
 #define READ_BARSETUP(vmidx, portidx, baridx) case IDT_SW_NTP ## portidx ## _BARSETUP ## baridx: \
             ret = shm_storage->vm ## vmidx .bar_config[baridx].setup; \
@@ -461,6 +468,14 @@ static void write_gasadata(IVShmemState *s, uint64_t val)
             s->gregs->segsigsts &= ~val; /* Substraction with a module of 2 */
             IVSHMEM_DPRINTF("GAS: Cleared the SEGSIGSTS, new value: 0x%x (vm%d)\n",
                     s->gregs->segsigsts, s->vm_id);
+            break;
+        case IDT_SW_SELINKDNSTS:
+            // TODO: switch event?
+            IVSHMEM_DPRINTF("GAS: Stub SELINKDNSTS write (not used in Linux driver)\n");
+            break;
+        case IDT_SW_SELINKUPSTS:
+            // TODO: switch event?
+            IVSHMEM_DPRINTF("GAS: Stub SELINKUPSTS write (not used in Linux driver)\n");
             break;
         default:
             IVSHMEM_DPRINTF("GAS: Not implemented gasadata write on reg 0x%lx\n", s->lregs.gasaaddr);


### PR DESCRIPTION
Should close #94.

Also:
- improves debug messages
- improves guest interrupt notifications (also makes it trivial to implement mask checking)

NTRDMA behavior changes somewhat:

VM1:
```dmesg
[  451.098441] ntrdma 0000:00:03.0: _ntc_link_enable: 1241: link enabled by ntrdma_probe
[  517.092290] ntrdma 0000:00:03.0: ntc_ntb_enabled: 783: checking if link is up
[  517.258613] ntrdma 0000:00:03.0: ntc_ntb_enabled: 783: checking if link is up
[  517.276864] ntrdma 0000:00:03.0: ntc_ntb_enabled: 783: checking if link is up
[  517.277240] ntrdma 0000:00:03.0: ntc_ntb_enabled: 787: link is up!
[  517.278051] ntc_ntb:set_memory_windows_on_device: logical MW0 @0x5d00000 len=0x100000
[  517.278153] ntc_ntb:set_memory_windows_on_device: ntb_mw_set_trans actual MW0 @0x5d00000 len=0x100000
```
VM2:
```dmesg
[  514.026858] ntrdma 0000:00:03.0: _ntc_link_enable: 1241: link enabled by ntrdma_probe
[ 1276.684079] ntrdma 0000:00:03.0: ntc_ntb_enabled: 783: checking if link is up
[ 1276.684326] ntrdma 0000:00:03.0: ntc_ntb_enabled: 787: link is up!
[ 1276.684906] ntc_ntb:set_memory_windows_on_device: logical MW0 @0x5400000 len=0x100000
[ 1276.684948] ntc_ntb:set_memory_windows_on_device: ntb_mw_set_trans actual MW0 @0x5400000 len=0x100000
```

During that 700 seconds that passes on VM2 it just continues to write something to inactive memory windows with constant speed. If one of the VMs unloads `ntrdma` module, writes stop.

**Despite that messages in kernel log, however, `/sys/class/infiniband/iwp0s3/link` still returns `0`**. No idea about that yet.