### PR TITLE
Support specifying target architecture in scripts

### DIFF
--- a/scripts/build_yocto.sh
+++ b/scripts/build_yocto.sh
@@ -17,8 +17,8 @@ if [[ $BUILD_VAL == "all" || $BUILD_VAL == "image" ]]; then
     bitbake -c deploy virtual/kernel
     bitbake core-image-full-cmdline
     # Create two image copies for VMs
-    cp -ruT tmp/deploy/images/qemux86-64/ ./guest_1
-    cp -ruT tmp/deploy/images/qemux86-64/ ./guest_2
+    cp -ruT tmp/deploy/images/qemu${NTB_CXL_ARCH}/ ./guest_1
+    cp -ruT tmp/deploy/images/qemu${NTB_CXL_ARCH}/ ./guest_2
 fi
 
 if [[ $BUILD_VAL == "all" || $BUILD_VAL == "qemu" ]]; then

--- a/scripts/parse_args.sh
+++ b/scripts/parse_args.sh
@@ -28,7 +28,7 @@ use extended flags with the suffix '-override', e.g. '--vm1-opts-override'
 
 
 export BUILD_VAL="all"
-
+export NTB_CXL_ARCH="x86_64"
 
 for ARGUMENT in "$@"; do
     KEY="$(echo "$ARGUMENT" | cut -f1 -d=)"
@@ -77,6 +77,9 @@ for ARGUMENT in "$@"; do
             ;;
         --qemu-map-ram-to-shm)
             export QEMU_SHM_SIZE="${VALUE:-1024}"
+            ;;
+        --arch)
+            export NTB_CXL_ARCH="$VALUE"
             ;;
         -h | --help)
             help

--- a/scripts/run_vm.sh
+++ b/scripts/run_vm.sh
@@ -17,7 +17,9 @@ if [ "$QEMU_SHM_SIZE" ]; then
 		-machine memory-backend=mem -m ${QEMU_SHM_SIZE}m"
 fi
 
-runqemu qemux86-64 nographic slirp qemuparams="$COMMON_OPTIONS ${VM1_OPTIONS_OVERRIDE:-$VM1_OPTIONS}"
+ARCH="$NTB_CXL_ARCH"
+
+runqemu qemu${ARCH//_/-} nographic slirp qemuparams="$COMMON_OPTIONS ${VM1_OPTIONS_OVERRIDE:-$VM1_OPTIONS}"
 
 set +x
 


### PR DESCRIPTION
`--arch=riscv64`.

Currently the architecture must also be changed manually in `yocto_files/configs/local.conf`.

Also the riscv64 virt machine doesn't boot at all.